### PR TITLE
CORSルート設定変更のためWebConfigクラスの実装完了

### DIFF
--- a/src/main/java/com/portfolio/portfolio_backend/Config/WebConfig.java
+++ b/src/main/java/com/portfolio/portfolio_backend/Config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.portfolio.portfolio_backend.Config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${app.cors.allowed-origins}")
+    private String[] allowedOrigins;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry){
+        registry.addMapping("/api/**")
+                .allowedOrigins(allowedOrigins)
+                .allowedMethods("GET","PUT","POST","DELETE","OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+
+}

--- a/src/main/java/com/portfolio/portfolio_backend/Controller/FileController.java
+++ b/src/main/java/com/portfolio/portfolio_backend/Controller/FileController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.*;
 import java.util.Optional;
 
 @RestController
-@CrossOrigin(origins = "https://localhost:3000")
 @RequestMapping("/api")
 public class FileController {
 

--- a/src/main/java/com/portfolio/portfolio_backend/Controller/ProjectController.java
+++ b/src/main/java/com/portfolio/portfolio_backend/Controller/ProjectController.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 
 @RestController
 @RequestMapping("/api")
-@CrossOrigin(origins = "https://localhost:3000")
 public class ProjectController {
 
     @Autowired

--- a/src/main/java/com/portfolio/portfolio_backend/Controller/UserController.java
+++ b/src/main/java/com/portfolio/portfolio_backend/Controller/UserController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api")
-@CrossOrigin(origins = "https://localhost:3000")
+@CrossOrigin(origins = "https://localhost:5173")
 public class UserController {
 
     @Autowired

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,6 @@ sprint.datasource.driver-class-name = org.postgresql.Driver
 # JPA/Hibernate properties
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+
+
+app.cors.allowed-origins=http://localhost:5173


### PR DESCRIPTION
フロントエンドがAPIをたたくようにCORSルート設定を変更し、フロントエンドのURLを追加できるようにWebConfigクラスを実装します。