### PR TITLE
プロジェクトAPIたたくたびに、重複の情報表示の不具合修正完了

### DIFF
--- a/src/main/java/com/portfolio/portfolio_backend/Controller/ProjectController.java
+++ b/src/main/java/com/portfolio/portfolio_backend/Controller/ProjectController.java
@@ -1,14 +1,11 @@
 package com.portfolio.portfolio_backend.Controller;
 
 import com.portfolio.portfolio_backend.DTO.ProjectDto;
-import com.portfolio.portfolio_backend.Entity.Project;
-import com.portfolio.portfolio_backend.Repository.ProjectRepository;
 import com.portfolio.portfolio_backend.Service.ProjectService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,7 +17,7 @@ public class ProjectController {
     private ProjectService projectService;
 
     @GetMapping("/project/{userId}")
-    public ResponseEntity<List<Optional<ProjectDto>>> getProjectFromUser(@PathVariable Long userId){
+    public ResponseEntity<List<ProjectDto>> getProjectFromUser(@PathVariable Long userId){
 
         return ResponseEntity.ok(projectService.getProjectfromId(userId));
     }

--- a/src/main/java/com/portfolio/portfolio_backend/Service/ProjectService.java
+++ b/src/main/java/com/portfolio/portfolio_backend/Service/ProjectService.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -19,53 +20,47 @@ public class ProjectService {
     @Autowired
     private ProjectRepository projectRepository;
 
-    private Optional<Project> projectOptional;
+//    private Optional<Project> projectOptional;
+//
+//    private List<Optional<ProjectDto>> projectDtos = new ArrayList<>();
+//
+//    private Optional<ProjectDto> projectDto;
+//
+//    private List<Project> projects = new ArrayList<>();
 
-    private List<Optional<ProjectDto>> projectDtos = new ArrayList<>();
+    public List<ProjectDto> getProjectfromId(Long id){
 
-    private Optional<ProjectDto> projectDto;
+        List<Project> projects = projectRepository.findByUserId(id);
 
-    private List<Project> projects = new ArrayList<>();
-
-    public List<Optional<ProjectDto>> getProjectfromId(Long id){
-
-        projects = projectRepository.findByUserId(id);
-
-
-        for (Project project: projects){
-            projectOptional = Optional.of(project);
-            projectDto = projectOptional.map(p->{
-                List<String> lesson = Arrays.stream(p.getLessonLearn().split(","))
-                        .map(String::trim)
-                        .toList();
-
-                List<String> techStack = Arrays.stream(p.getTechStack().split(","))
-                        .map(String::trim)
-                        .toList();
-
-                return new ProjectDto(
-                        p.getId(),
-                        p.getProjectName(),
-                        p.getStartDate(),
-                        p.getEndDate(),
-                        p.getDetail(),
-                        techStack,
-                        p.getProjectSize(),
-                        p.getMyRole(),
-                        lesson
-                );
-
-            });
-
-            projectDtos.add(projectDto);
-
-
-
-        }
-
-        return projectDtos;
+            return projects.stream()
+                            .map(this::convertToDto)
+                                    .toList();
 
 
     }
+
+    private ProjectDto convertToDto(Project project){
+        List<String> lesson = Arrays.stream(project.getLessonLearn().split(","))
+                .map(String::trim)
+                .toList();
+
+        List<String> techStack = Arrays.stream(project.getTechStack().split(","))
+                .map(String::trim)
+                .toList();
+
+        return new ProjectDto(
+                project.getId(),
+                project.getProjectName(),
+                project.getStartDate(),
+                project.getEndDate(),
+                project.getDetail(),
+                techStack,
+                project.getProjectSize(),
+                project.getMyRole(),
+                lesson
+        );
+
+    }
+
 
 }


### PR DESCRIPTION
例えば、DBにレコード数が2個しかない。APIを最初にたたくと、JSONが2レコードに応じて正しく返るが、ブラウザをリフレッシュをして、JSONの4個返って、その中に重複レコンギスタが存在します。

原因調査：サービスクラスにJSON返却処理ごとにプロジェクトリストを空にすることないので、毎回APIたたくと、重複レコードが出ます。

解決：プロジェクトリスト処理のロジックを別のメソッドに移動する。